### PR TITLE
Enable colored output for clang/gcc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,15 @@ project(Fwog)
 
 set(CMAKE_CXX_STANDARD 20)
 
+option (FORCE_COLORED_OUTPUT "Always produce ANSI-colored output (GNU/Clang only)." TRUE)
+if (${FORCE_COLORED_OUTPUT})
+    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+       add_compile_options (-fdiagnostics-color=always)
+    elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+       add_compile_options (-fcolor-diagnostics)
+    endif ()
+endif ()
+
 add_subdirectory(external)
 
 set(fwog_source_files


### PR DESCRIPTION
can be switched off via flag

![image](https://user-images.githubusercontent.com/15695435/182002053-475c5db5-a663-46d3-a815-dbd05ca149d7.png)
