### PR TITLE
Center window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ build/
 
 # Large/test assets
 /example/models
+
+# Clang cache
+.cache/

--- a/example/common/Application.cpp
+++ b/example/common/Application.cpp
@@ -150,6 +150,7 @@ Application::Application(const CreateInfo& createInfo)
   window = glfwCreateWindow(int(videoMode->width * .75), int(videoMode->height * .75), createInfo.name.data(), nullptr, nullptr);
   if (!window)
   {
+    glfwTerminate();
     throw std::runtime_error("Failed to create window");
   }
 

--- a/example/common/Application.cpp
+++ b/example/common/Application.cpp
@@ -160,6 +160,8 @@ Application::Application(const CreateInfo& createInfo)
   windowWidth = static_cast<uint32_t>(xSize);
   windowHeight = static_cast<uint32_t>(ySize);
 
+  glfwSetWindowPos(window, videoMode->width / 2 - windowWidth / 2, videoMode->height / 2 - windowHeight / 2);
+
   glfwSetWindowUserPointer(window, this);
   glfwMakeContextCurrent(window);
   glfwSwapInterval(createInfo.vsync ? 1 : 0);

--- a/example/common/Application.cpp
+++ b/example/common/Application.cpp
@@ -148,17 +148,16 @@ Application::Application(const CreateInfo& createInfo)
   GLFWmonitor* monitor = glfwGetPrimaryMonitor();
   const GLFWvidmode* videoMode = glfwGetVideoMode(monitor);
   window = glfwCreateWindow(int(videoMode->width * .75), int(videoMode->height * .75), createInfo.name.data(), nullptr, nullptr);
+  if (!window)
+  {
+    throw std::runtime_error("Failed to create window");
+  }
 
   int xSize{};
   int ySize{};
   glfwGetFramebufferSize(window, &xSize, &ySize);
   windowWidth = static_cast<uint32_t>(xSize);
   windowHeight = static_cast<uint32_t>(ySize);
-
-  if (!window)
-  {
-    throw std::runtime_error("Failed to create window");
-  }
 
   glfwSetWindowUserPointer(window, this);
   glfwMakeContextCurrent(window);


### PR DESCRIPTION
This PR cleans up a few things:

- clang cache folder being added to gitignore
- when window cannot be created fail earlier, rather than at glfwGetFramebufferSize throwing a tantrum
- cleanup glfw before leaving application in case of an error in above situation

And also centers the main window after its creation.