### PR TITLE
Fixes empty infoLog upon compile error

### DIFF
--- a/src/Shader.cpp
+++ b/src/Shader.cpp
@@ -35,11 +35,12 @@ namespace Fwog
     glGetShaderiv(id, GL_COMPILE_STATUS, &success);
     if (!success)
     {
-      glDeleteShader(id);
+     
       std::string infoLog;
       const GLsizei infoLength = 512;
       infoLog.resize(infoLength + 1, '\0');
       glGetShaderInfoLog(id, infoLength, nullptr, infoLog.data());
+      glDeleteShader(id);
       throw ShaderCompilationException("Failed to compile shader source.\n" + infoLog);
     }
 


### PR DESCRIPTION
glDeleteShader() being called before glGetShaderInfoLog() causes the infolog to be empty and unpopulated if an error happens.

Before:
![image](https://user-images.githubusercontent.com/26779639/232279913-78a3bf9b-6c0c-4d71-ab15-b3c4b347b606.png)


After:
![image](https://user-images.githubusercontent.com/26779639/232279931-ff4da7a6-cd86-4303-9904-e95e219d2f74.png)

