### PR TITLE
More explict assert if Fwog::Initialize() was not called to avoid misleading assert message

### DIFF
--- a/src/Rendering.cpp
+++ b/src/Rendering.cpp
@@ -163,6 +163,8 @@ namespace Fwog
 
   void BeginSwapchainRendering(const SwapchainRenderInfo& renderInfo)
   {
+    FWOG_ASSERT(context != nullptr && "Fwog has not been initialized");
+
     FWOG_ASSERT(!context->isRendering && "Cannot call BeginRendering when rendering");
     FWOG_ASSERT(!context->isComputeActive && "Cannot nest compute and rendering");
     context->isRendering = true;
@@ -266,6 +268,7 @@ namespace Fwog
 
   void BeginRendering(const RenderInfo& renderInfo)
   {
+    FWOG_ASSERT(context != nullptr && "Fwog has not been initialized");
     FWOG_ASSERT(!context->isRendering && "Cannot call BeginRendering when rendering");
     FWOG_ASSERT(!context->isComputeActive && "Cannot nest compute and rendering");
     context->isRendering = true;


### PR DESCRIPTION
Made a mistake while working on something and got this misleading error message. I was able to infer that I had forgotten to call Fwog::Initalize() but the assert does not hint at it beyond that the context was a nullptr. At first, I took the assert message literally and was confused how it could be already rendering before I realized the silly mistake in my own code.

![image](https://github.com/JuanDiegoMontoya/Fwog/assets/26779639/09740065-afe9-4347-a487-ca104ca051fc)

Made this pull request to address it.